### PR TITLE
Catch Guzzle server exceptions

### DIFF
--- a/libs/functions.php
+++ b/libs/functions.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
 
 function get_all_webhooks($form_id=0)
 {
@@ -103,6 +104,8 @@ function webhooks_post_all($data, $action_type)
             // Throws a ConnectException if any of the requests fail
             Promise\unwrap($promises);
         } catch (ConnectException $connectException) {
+            // Do nothing on errors...
+        } catch (ServerException $serverException) {
             // Do nothing on errors...
         }
 


### PR DESCRIPTION
Sometimes Guzzle returns a Server Exception even though the data are correctly posted.
To avoid a blank page after posting data, we silently catch this exception.