### PR TITLE
Enable webhooks when editing in iframes

### DIFF
--- a/handlers/page/__editiframe.php
+++ b/handlers/page/__editiframe.php
@@ -1,0 +1,16 @@
+<?php
+
+// Vérification de sécurité
+if (!defined("WIKINI_VERSION")) {
+    die("acc&egrave;s direct interdit");
+}
+
+if ($this->HasAccess('write')) {
+    $type = $this->GetTripleValue($this->GetPageTag(), 'http://outils-reseaux.org/_vocabulary/type', '', '');
+
+    if ($type == 'fiche_bazar') {
+        if (isset($_POST['bf_titre'])) {
+            webhooks_post_all($_POST, WEBHOOKS_ACTION_EDIT);
+        }
+    }
+}


### PR DESCRIPTION
Currently we were calling the webhook on the `handlers/page/__edit.php` file, but this file is not called when we are on an iframe.