### PR TITLE
feat(webhooks_format): create yeswiki format

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ parameters:
     activitypub: 'WEBHOOKS_FORMAT_ACTIVITYPUB'
     mattermost: 'WEBHOOKS_FORMAT_MATTERMOST'
     slack: 'WEBHOOKS_FORMAT_SLACK'
+    yeswiki: 'WEBHOOKS_FORMAT_YESWIKI'
   webhooks_activitypub_default_actor: '' # If no actor field is defined semantically, this value will be used
   webhooks_activitypub_actors_base_url: '' # If an actor is defined, we can override the base URL with this config
   # Bot config (works for Mattermost if username and profile picture override is enabled)

--- a/lang/webhooks_fr.inc.php
+++ b/lang/webhooks_fr.inc.php
@@ -9,6 +9,7 @@ $GLOBALS['translations'] = array_merge(
         'WEBHOOKS_FORMAT_ACTIVITYPUB' => 'ActivityPub',
         'WEBHOOKS_FORMAT_MATTERMOST' => 'Mattermost',
         'WEBHOOKS_FORMAT_SLACK' => 'Slack',
+        'WEBHOOKS_FORMAT_YESWIKI' => 'YesWiki',
         'WEBHOOKS_URL_PLACEHOLDER' => 'Adresse URL',
         'WEBHOOKS_UPDATE' => 'Mettre à jour',
         'WEBHOOKS_ANONYMOUS_USER' => 'Anonyme',

--- a/libs/functions.php
+++ b/libs/functions.php
@@ -141,7 +141,7 @@ function format_json_data($format, $data)
         case WEBHOOKS_FORMAT_YESWIKI:
             // remove not used fields
             foreach ($data['data'] as $key => $value) {
-                if (!in_array($key, ['id_fiche','bf_titre','id_typeannonce'], true)) {
+                if (!in_array($key, ['id_fiche','bf_titre','id_typeannonce','url','date_maj_fiche'], true)) {
                     unset($data['data'][$key]);
                 }
             }

--- a/libs/functions.php
+++ b/libs/functions.php
@@ -137,7 +137,62 @@ function format_json_data($format, $data)
 
         case WEBHOOKS_FORMAT_SLACK:
             return ["text" => $data['text']];
+
+        case WEBHOOKS_FORMAT_YESWIKI:
+            // remove not used fields
+            foreach ($data['data'] as $key => $value) {
+                if (!in_array($key, ['id_fiche','bf_titre','id_typeannonce'], true)) {
+                    unset($data['data'][$key]);
+                }
+            }
+            $data['base_url'] = $GLOBALS['wiki']->config['base_url'];
+            return $data;
     }
+}
+
+/**
+ * update $webhook['url'], $data and options according to $webhook['format']
+ * @param $webhook
+ * @param array $data
+ * @return array [$url, $options (to merge to current options))]
+ */
+function extract_url_options($webhook, $data)
+{
+    $options = [];
+    switch ($webhook['format']) {
+        case WEBHOOKS_FORMAT_YESWIKI:
+            $query = parse_url($webhook['url'], PHP_URL_QUERY);
+            if (!empty($query)) {
+                parse_str($query, $queries);
+
+                // get bearer
+                if (isset($queries['bearer'])) {
+                    if (!empty($queries['bearer'])) {
+                        $options['headers'] = ['Authorization' => 'Bearer '. $queries['bearer']];
+                    }
+                    unset($queries['bearer']);
+                }
+
+                // refresh url
+                array_walk($queries, function (&$item, $key) {
+                    $item = empty($item)
+                        ? $key
+                        : (
+                            is_array($item)
+                            ? $key.'='.implode(',', $item)
+                            : $key.'='.$item
+                        );
+                });
+                $newQuery = implode('&', $queries);
+                $url = str_replace($query, $newQuery, $webhook['url']);
+            }
+            break;
+        
+        default:
+            $url = $webhook['url'];
+            break;
+    }
+    return [$url, $options];
 }
 
 function webhooks_post_all($data, $action_type)
@@ -186,7 +241,11 @@ function webhooks_post_all($data, $action_type)
         ]]);
 
         $promises = array_map(function ($webhook) use ($client, $data_to_send) {
-            return $client->postAsync($webhook['url'], ['json' => format_json_data($webhook['format'], $data_to_send)]);
+            list($url, $options) = extract_url_options($webhook, $data_to_send);
+            return $client->postAsync(
+                $url,
+                $options + ['json' => format_json_data($webhook['format'], $data_to_send)]
+            );
         }, $webhooks);
 
         try {

--- a/wiki.php
+++ b/wiki.php
@@ -13,6 +13,7 @@ define('WEBHOOKS_FORMAT_RAW', 'raw');
 define('WEBHOOKS_FORMAT_ACTIVITYPUB', 'activitypub');
 define('WEBHOOKS_FORMAT_MATTERMOST', 'mattermost');
 define('WEBHOOKS_FORMAT_SLACK', 'slack');
+define('WEBHOOKS_FORMAT_YESWIKI', 'yeswiki');
 
 define('WEBHOOKS_VUE_TEST', 'test-webhook');
 


### PR DESCRIPTION
@mrflos serais-tu d'accord pour introduire le format `YesWiki` dans les `webhooks` envoyés ?

**PR DRAFT pour le moment, le temps de parler des specs sur le format**

le format `YesWiki` tel que je le propose fait ceci:
 - envoyer dans les données uniquement `bf_titre`, `id_tyeannonce`, `id_fiche` afin de ne pas avoir à gérer les acls sur les autres champs (les données devront être récupérées par le site cible par un appel sur l'`api`)
 - possibilité de définir un `bearer` pour les appels sur l'`api` du site cible qu'on rajoute dans l'url `https://www.example.com/?api/my-route&bearer=<secret>`
 - retrait de ce `bearer` de l'url pour le mettre dans les en-têtes http ce qui donne lors de l'envoi:
   - url `https://www.example.com/?api/my-route&`
   - en-tête http `Authorization : Bearer <secret>`