### PR TITLE
feat(Comments): send webhooks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,5 +18,7 @@ services:
     public: true
 
   # Allows to use controllers as services
-  YesWiki\Webhooks\Controller\:
-    resource: 'controllers/*'
+  YesWiki\Webhooks\Controller\WebhooksController:
+    class: YesWiki\Webhooks\Controller\WebhooksController
+    tags:
+      - { name: yeswiki.event_subscriber }

--- a/controllers/WebhooksController.php
+++ b/controllers/WebhooksController.php
@@ -14,6 +14,7 @@ use YesWiki\Bazar\Service\FormManager;
 use YesWiki\Bazar\Service\SemanticTransformer;
 use YesWiki\Core\Entity\Event;
 use YesWiki\Core\Service\AclService;
+use YesWiki\Core\Service\EventDispatcher;
 use YesWiki\Core\Service\TripleStore;
 use YesWiki\Core\Service\UserManager;
 use YesWiki\Core\YesWikiController;
@@ -105,6 +106,11 @@ class WebhooksControllerCommons extends YesWikiController
         $this->debugMode = null;
     }
 
+    protected function showComments(): bool
+    {
+        return $this->wiki->services->has(EventDispatcher::class);
+    }
+
     private function getDebugMode(): bool
     {
         if (is_null($this->debugMode)) {
@@ -184,7 +190,8 @@ class WebhooksControllerCommons extends YesWikiController
             'url' => getAbsoluteUrl(),
             'webhooks' => $this->get_all_webhooks(),
             'forms' => $this->formManager->getAll(),
-            'formats' => $this->params->get('webhooks_formats')
+            'formats' => $this->params->get('webhooks_formats'),
+            'showComment' => $this->showComments()
         ]);
     }
 

--- a/controllers/WebhooksController.php
+++ b/controllers/WebhooksController.php
@@ -8,9 +8,11 @@ use GuzzleHttp\Promise;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ServerException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use YesWiki\Bazar\Service\EntryManager;
 use YesWiki\Bazar\Service\FormManager;
 use YesWiki\Bazar\Service\SemanticTransformer;
+use YesWiki\Core\Entity\Event;
 use YesWiki\Core\Service\AclService;
 use YesWiki\Core\Service\TripleStore;
 use YesWiki\Core\Service\UserManager;
@@ -18,11 +20,64 @@ use YesWiki\Core\YesWikiController;
 use YesWiki\Wiki;
 use Throwable;
 
-class WebhooksController extends YesWikiController
+// Check the interface exists before trying to use it
+if (interface_exists(EventSubscriberInterface::class)) {
+    class WebhooksController extends WebhooksControllerCommons implements EventSubscriberInterface
+    {
+        public static function getSubscribedEvents()
+        {
+            return [
+                WebhooksControllerCommons::WEBHOOKS_ACTION_CREATE_COMMENT => 'sendCommentCreatedWebHook',
+                WebhooksControllerCommons::WEBHOOKS_ACTION_MODIFY_COMMENT => 'sendCommentModifiedWebHook',
+                WebhooksControllerCommons::WEBHOOKS_ACTION_DELETE_COMMENT => 'sendCommentDeletedWebHook'
+            ];
+        }
+
+        /**
+         * @param Event $event
+         */
+        public function sendCommentCreatedWebHook($event)
+        {
+            // array
+            $data = $event->getData();
+            $this->securedExecution([$this,'webhooks_post_all'], $data, self::WEBHOOKS_ACTION_CREATE_COMMENT);
+        }
+
+        /**
+         * @param Event $event
+         */
+        public function sendCommentModifiedWebHook($event)
+        {
+            // array
+            $data = $event->getData();
+            $this->securedExecution([$this,'webhooks_post_all'], $data, self::WEBHOOKS_ACTION_MODIFY_COMMENT);
+        }
+
+        /**
+         * @param Event $event
+         */
+        public function sendCommentDeletedWebHook($event)
+        {
+            // array
+            $data = $event->getData();
+            $this->securedExecution([$this,'webhooks_post_all'], $data, self::WEBHOOKS_ACTION_DELETE_COMMENT);
+        }
+    }
+} else {
+    class WebhooksController extends WebhooksControllerCommons
+    {
+    }
+}
+
+class WebhooksControllerCommons extends YesWikiController
 {
-    protected $entryManager;
+    public const WEBHOOKS_ACTION_CREATE_COMMENT = 'comments.create';
+    public const WEBHOOKS_ACTION_MODIFY_COMMENT = 'comments.modify';
+    public const WEBHOOKS_ACTION_DELETE_COMMENT = 'comments.delete';
+
     protected $aclService;
     protected $debugMode;
+    protected $entryManager;
     protected $formManager;
     protected $params;
     protected $semanticTransformer;
@@ -64,7 +119,7 @@ class WebhooksController extends YesWikiController
             && isset($_GET['action']) && $_GET['action'] === 'voir_fiche'
             && !empty($_GET['id_fiche']) && preg_match("/^". WN_CAMEL_CASE_EVOLVED ."$/m", $_GET['id_fiche'])
             && isset($_GET['message']) && $_GET['message'] === 'modif_ok'
-            ) {
+        ) {
             if ($this->aclService->hasAccess('write', $_GET['id_fiche'])
                 && $this->entryManager->isEntry($_GET['id_fiche'])) {
                 $entry = $this->entryManager->getOne($_GET['id_fiche']);
@@ -124,7 +179,7 @@ class WebhooksController extends YesWikiController
         if (!empty($_POST['url']) && $this->wiki->UserIsAdmin()) {
             $this->registerWebhooks();
         }
-    
+
         return $this->render('@webhooks/webhooks_form.twig', [
             'url' => getAbsoluteUrl(),
             'webhooks' => $this->get_all_webhooks(),
@@ -147,7 +202,7 @@ class WebhooksController extends YesWikiController
                     $this->wiki->exit(_t('WEBHOOKS_ERROR_INVALID_URL'));
                 }
 
-                $formId = intval($_POST['form'][$i]);
+                $formId = ($_POST['form'][$i] !== "comments") ? intval($_POST['form'][$i]) : "comments";
                 // If ActivityPub is selected, check that the selected form(s) are semantic
                 if ($_POST['format'][$i] === WEBHOOKS_FORMAT_ACTIVITYPUB) {
                     if ($formId === 0) {
@@ -157,7 +212,7 @@ class WebhooksController extends YesWikiController
                                 $this->wiki->exit(_t('WEBHOOKS_ERROR_FORM_NOT_SEMANTIC'));
                             }
                         }
-                    } else {
+                    } elseif ($formId !== "comments") {
                         // Check that the selected form is semantic
                         $form = $this->formManager->getOne($formId);
                         if (!$form['bn_sem_type']) {
@@ -197,7 +252,7 @@ class WebhooksController extends YesWikiController
         } else {
             // Return only webhooks which must be called for this form_id
             return(array_filter($all_webhooks, function ($webhook) use ($form_id) {
-                return(!isset($webhook['form']) || $webhook['form']===0 || $webhook['form']===$form_id);
+                return(!isset($webhook['form']) || ($form_id != "comments" && $webhook['form']===0) || $webhook['form']===$form_id);
             }));
         }
     }
@@ -213,14 +268,23 @@ class WebhooksController extends YesWikiController
 
     protected function get_notification_text($data, $action_type, $user_name)
     {
-        $idformulaire = $data['id_typeannonce'] ?? '';
-        if (is_array($idformulaire) and count($idformulaire) > 0) {
-            $idformulaire = $idformulaire[0];
-        }
-        if (!empty($idformulaire) && strval($idformulaire) == strval(intval($idformulaire))) {
-            $formulaire = $this->formManager->getOne($idformulaire);
-        } else {
-            $formulaire = ($this->formManager->getAll())[0];
+        switch ($action_type) {
+            case self::WEBHOOKS_ACTION_CREATE_COMMENT:
+            case self::WEBHOOKS_ACTION_MODIFY_COMMENT:
+            case self::WEBHOOKS_ACTION_DELETE_COMMENT:
+                $formulaire = "";
+                break;
+            default:
+                $idformulaire = $data['id_typeannonce'] ?? '';
+                if (is_array($idformulaire) and count($idformulaire) > 0) {
+                    $idformulaire = $idformulaire[0];
+                }
+                if (!empty($idformulaire) && strval($idformulaire) == strval(intval($idformulaire))) {
+                    $formulaire = $this->formManager->getOne($idformulaire);
+                } else {
+                    $formulaire = ($this->formManager->getAll())[0];
+                }
+                break;
         }
         $tabData = [
             'data' => $data,
@@ -235,6 +299,12 @@ class WebhooksController extends YesWikiController
                 return $this->render('@webhooks/message-edit.twig', $tabData);
             case WEBHOOKS_ACTION_DELETE:
                 return $this->render('@webhooks/message-delete.twig', $tabData);
+            case self::WEBHOOKS_ACTION_CREATE_COMMENT:
+                return $this->render('@webhooks/message-create-comment.twig', $tabData);
+            case self::WEBHOOKS_ACTION_MODIFY_COMMENT:
+                return $this->render('@webhooks/message-modify-comment.twig', $tabData);
+            case self::WEBHOOKS_ACTION_DELETE_COMMENT:
+                return $this->render('@webhooks/message-delete-comment.twig', $tabData);
         }
     }
 
@@ -381,7 +451,7 @@ class WebhooksController extends YesWikiController
                     $url = str_replace($query, $newQuery, $webhook['url']);
                 }
                 break;
-            
+
             default:
                 $url = $webhook['url'];
                 break;
@@ -391,16 +461,24 @@ class WebhooksController extends YesWikiController
 
     public function webhooks_post_all($data, $action_type)
     {
-        if (!isset($data['id_typeannonce'])) {
-            throw new Exception("Webhook error: unable to determine the form ID (id_typeannonce is not defined)");
-        }
+        switch ($action_type) {
+            case self::WEBHOOKS_ACTION_CREATE_COMMENT:
+            case self::WEBHOOKS_ACTION_MODIFY_COMMENT:
+            case self::WEBHOOKS_ACTION_DELETE_COMMENT:
+                $form_id = "comments";
+                break;
+            default:
+                if (!isset($data['id_typeannonce'])) {
+                    throw new Exception("Webhook error: unable to determine the form ID (id_typeannonce is not defined)");
+                }
 
-        $form_id = intval($data['id_typeannonce']);
+                $form_id = intval($data['id_typeannonce']);
+                break;
+        }
 
         $webhooks = $this->get_all_webhooks($form_id);
 
         if (count($webhooks) > 0) {
-
             // Add the semantic data if they don't already exist
 
             if (!isset($data['semantic'])) {

--- a/lang/webhooks_en.inc.php
+++ b/lang/webhooks_en.inc.php
@@ -14,4 +14,5 @@ return [
     'WEBHOOKS_ERROR_INVALID_URL' => 'The given link is invalid',
     'WEBHOOKS_ERROR_FORM_NOT_SEMANTIC' => 'One or more selected form is not semantic, the ActivityPub format cannot be used',
     'WEBHOOKS_VISIBLE_ONLY_FOR_ADMINS' => 'Only visible by admins',
+    'WEBHOOKS_COMMENTS' => "Comments",
 ];

--- a/lang/webhooks_fr.inc.php
+++ b/lang/webhooks_fr.inc.php
@@ -17,4 +17,5 @@ return [
     'WEBHOOKS_VISIBLE_ONLY_FOR_ADMINS' => 'Visible uniquement pour les administrateurs',
     'WEBHOOKS_POST_ERROR' => "Une action d'arrière-plan ne s'est pas déroulée comme prévue.\nVous pouvez prévenir les administrateurs pour les aider à maintenir ce site en leur donnant cette information :\n erreur exécutant '{function}' dans '{method}'.",
     'WEBHOOKS_FORCE_DELETE' => "Forcer la suppression de la fiche sans envoyer de webhook !",
+    'WEBHOOKS_COMMENTS' => "Commentaires",
 ];

--- a/lang/webhooks_pt.inc.php
+++ b/lang/webhooks_pt.inc.php
@@ -14,4 +14,5 @@ return [
     'WEBHOOKS_ERROR_INVALID_URL' => 'O link fornecido não é válido',
     'WEBHOOKS_ERROR_FORM_NOT_SEMANTIC' => 'Um ou vários formulários selecionados não estão semanticamente definidos, o formato ActivityPub não pode ser usado',
     // 'WEBHOOKS_VISIBLE_ONLY_FOR_ADMINS' => 'Visible uniquement pour les administrateurs',
+    // 'WEBHOOKS_COMMENTS' => "Commentaires",
 ];

--- a/templates/message-create-comment.twig
+++ b/templates/message-create-comment.twig
@@ -1,0 +1,6 @@
+**AJOUT** Commentaire "{{ data.comment.tag }}" ({{ url }}{{ data.comment.tag }})
+{% if data.comment.commentOn != data.comment.parentPage.tag %}
+en réponse à "{{ data.comment.commentOn }}" ({{ url }}{{ data.comment.commentOn }})
+{% endif %}
+sur la page "{{ data.comment.parentPage.tag }}" ({{ url }}{{ data.comment.parentPage.tag }}),
+ajouté par {{ user }}

--- a/templates/message-delete-comment.twig
+++ b/templates/message-delete-comment.twig
@@ -1,0 +1,2 @@
+**SUPPRESSION** Commentaire "{{ data.comment.tag }}"{% if data.parentPage.tag %} sur la page "{{ data.parentPage.tag }}"{% endif %} supprimé par {{ user }}
+{% if data.parentPage.tag %}{{ url }}{{ data.parentPage.tag }}{% endif %}

--- a/templates/message-modify-comment.twig
+++ b/templates/message-modify-comment.twig
@@ -1,0 +1,3 @@
+**MODIFICATION** Commentaire "{{ data.comment.tag }}" ({{ url }}{{ data.comment.tag }}) de {{ data.comment.owner }}
+sur la page "{{ data.comment.parentPage.tag }}" ({{ url }}{{ data.comment.parentPage.tag }}),
+mis à jour par {{ user }}

--- a/templates/webhooks_form.twig
+++ b/templates/webhooks_form.twig
@@ -20,6 +20,7 @@
                     {% for form in forms %}
                         <option value="{{ form.bn_id_nature }}" {{ (webhooks[i] is defined and (webhooks[i].form)|number_format is same as form.bn_id_nature) ? "selected" : "" }}>{{ form.bn_label_nature }}</option>
                     {% endfor %}
+                    <option value="comments" {{ (webhooks[i] is defined and webhooks[i].form == 'comments') ? "selected" : "" }}>{{ _t('WEBHOOKS_COMMENTS') }}</option>
                 </select>
             </div>
             <div class="col-sm-8">

--- a/templates/webhooks_form.twig
+++ b/templates/webhooks_form.twig
@@ -20,7 +20,9 @@
                     {% for form in forms %}
                         <option value="{{ form.bn_id_nature }}" {{ (webhooks[i] is defined and (webhooks[i].form)|number_format is same as form.bn_id_nature) ? "selected" : "" }}>{{ form.bn_label_nature }}</option>
                     {% endfor %}
+                    {% if showComment %}
                     <option value="comments" {{ (webhooks[i] is defined and webhooks[i].form == 'comments') ? "selected" : "" }}>{{ _t('WEBHOOKS_COMMENTS') }}</option>
+                    {% endif %}
                 </select>
             </div>
             <div class="col-sm-8">


### PR DESCRIPTION
cette PR est liée à la PR du coeur https://github.com/YesWiki/yeswiki/pull/967 sur les commentaires

Elle permet d'attraper les événements liées aux commentaires (événements définis via EventDispatcher de la librairie symfony, cf. la PR du coeur)

et ensuite, elle permet aussi de formater en envoyer des webhooks associés aux commentaires

_PR draft en attendant la fusion de la P du coeur_

**Ce que ça fait**:
 - décoration du `CommentService` pour éviter les erreurs en cas d'installation de Webhooks avec cette PR sur des versions antérieures à `4.2`
 - mise en place du suivi des commentaires dans `WebhooksController`
 - création de template `twig` pour gérer le formatage des messages des webhooks
 - ajout de l'option pour suivre les commentaires au sein de l'interface présente en bas de l'action `bazar`