### PR TITLE
The webhooks extension was using the deprecated Guzzle Promise API:  WebhooksController.php

### DIFF
--- a/controllers/WebhooksController.php
+++ b/controllers/WebhooksController.php
@@ -554,18 +554,19 @@ class WebhooksControllerCommons extends YesWikiController
             }, $webhooks);
 
             try {
-                // Wait on all of the requests to complete.
-                // Throws a ConnectException if any of the requests fail
-                Promise\unwrap($promises);
-            } catch (ConnectException $connectException) {
-                // Do nothing on errors...
-            } catch (ServerException $serverException) {
-                // Do nothing on errors...
+                Promise\Utils::unwrap($promises);
+                error_log('[WEBHOOKS DEBUG] Envoi webhook terminé');
+            } catch (ConnectException $e) {
+                error_log('[WEBHOOKS DEBUG] ConnectException: ' . $e->getMessage());
+            } catch (ServerException $e) {
+                error_log('[WEBHOOKS DEBUG] ServerException: ' . $e->getMessage());
+            } catch (\Throwable $e) {
+                error_log('[WEBHOOKS DEBUG] Exception générale: ' . $e->getMessage());
             }
 
             // Wait for the requests to complete, otherwise the code may end before the request is sent
             // TODO: try to make it work without this command, so that webhooks can be sent asyncronously
-            Promise\settle($promises)->wait();
+            Promise\Utils::settle($promises)->wait();
         }
     }
 }


### PR DESCRIPTION
Fix webhook delivery with Guzzle Promises 2.x compatibility

The webhooks extension was using the deprecated Guzzle Promise API:
- GuzzleHttp\Promise\unwrap()
- GuzzleHttp\Promise\settle()

These functions are no longer available in guzzlehttp/promises 2.x and caused webhook sending to fail with: "Call to undefined function GuzzleHttp\Promise\unwrap()"

Replace them with the new API:
- GuzzleHttp\Promise\Utils::unwrap()
- GuzzleHttp\Promise\Utils::settle()

This restores outgoing webhook notifications (e.g. Mattermost) with current Guzzle versions.